### PR TITLE
Refactor setting region for AWS api

### DIFF
--- a/src/commands/logs.js
+++ b/src/commands/logs.js
@@ -10,7 +10,6 @@ export function builder (yargs) {
   .pkgConf('shep', process.cwd())
   .describe('env', 'Specifies which environment to use. If not provided an interactive menu will display the options.')
   .describe('name', 'Name of function to use')
-  .describe('region', 'Name of region to use, uses region in `package.json` if not given')
   .boolean('stream')
   .default('stream', true)
   .describe('stream', 'Stream logs')

--- a/src/config-list/index.js
+++ b/src/config-list/index.js
@@ -12,6 +12,7 @@ export default async function (opts) {
   if (opts.json) {
     if (Object.keys(conflicts).length !== 0 || Object.keys(differences).length !== 0) { throw new Error('Environments are out of sync, run `shep config sync` to fix') }
     console.log(JSON.stringify(common, undefined, 2))
+    return common
   } else {
     console.log('Common Variables:')
     console.log(values(common).map(({ key, value }) => `${key}=${value}`).join('\n'))
@@ -28,5 +29,6 @@ export default async function (opts) {
         return `Variable: ${key}\n${funcValues.join('\n')}`
       }).join('\n'))
     }
+    return { common, differences, conflicts }
   }
 }

--- a/src/config-remove/index.js
+++ b/src/config-remove/index.js
@@ -1,11 +1,8 @@
 import remove from '../util/remove-environment'
 import listr from '../util/modules/listr'
-import AWS from 'aws-sdk'
 
 export default function (opts) {
   const env = opts.env || 'development'
-
-  AWS.config.update({region: opts.region})
 
   const tasks = listr([
     {

--- a/src/config-set/index.js
+++ b/src/config-set/index.js
@@ -1,11 +1,8 @@
 import upload from '../util/upload-environment'
 import listr from '../util/modules/listr'
-import AWS from 'aws-sdk'
 
 export default function (opts) {
   const env = opts.env || 'development'
-
-  AWS.config.update({region: opts.region})
 
   const tasks = listr([
     {

--- a/src/config-sync/index.js
+++ b/src/config-sync/index.js
@@ -1,15 +1,11 @@
 import Promise from 'bluebird'
 import * as load from '../util/load'
 import { environmentCheck, values } from '../util/environment-check'
-import AWS from '../util/aws'
 import { isFunctionDeployed, listAliases } from '../util/aws/lambda'
 import getFunctionEnvs from '../util/get-function-envs'
 import uploadEnvironment from '../util/upload-environment'
 
 export default async function (specifiedAlias) {
-  const pkg = await load.pkg()
-  AWS.config.update({ region: pkg.shep.region })
-
   const funcConfigs = await Promise.map(load.funcs(), load.lambdaConfig)
   const deployedFuncs = await Promise.filter(funcConfigs, ({ FunctionName }) => isFunctionDeployed(FunctionName))
   const allFuncAliases = await Promise.map(deployedFuncs, ({ FunctionName }) => listAliases(FunctionName))

--- a/src/deploy/index.js
+++ b/src/deploy/index.js
@@ -6,7 +6,6 @@ import promoteAliases from '../util/promote-aliases'
 import setPermissions from '../util/set-permissions'
 import * as load from '../util/load'
 import push from '../util/push-api'
-import AWS from 'aws-sdk'
 import listr from '../util/modules/listr'
 
 export default async function (opts) {
@@ -21,8 +20,6 @@ export default async function (opts) {
   let shouldUpload = true
 
   if (opts.apiId) { apiId = opts.apiId }
-
-  AWS.config.update({ region })
 
   const tasks = listr([
     {

--- a/src/logs/index.js
+++ b/src/logs/index.js
@@ -1,17 +1,13 @@
 import Promise from 'bluebird'
-import AWS from '../util/aws'
 import { getLogGroup } from '../util/aws/cloudwatch-logs'
 import { getAliasVersion } from '../util/aws/lambda'
 import getLogs from '../util/get-logs'
-import { pkg, lambdaConfig } from '../util/load'
+import { lambdaConfig } from '../util/load'
 
 export default async function (opts) {
   const { FunctionName } = await lambdaConfig(opts.name)
   const aliasName = opts.env
   const stream = opts.stream
-  const region = opts.region || (await pkg()).shep.region
-
-  AWS.config.update({ region })
 
   const [logGroupName, functionVersion] = await Promise.all([getLogGroup({ FunctionName }), getAliasVersion({ functionName: FunctionName, aliasName })])
   const logs = await getLogs({ logGroupName, functionVersion, stream })

--- a/src/push/index.js
+++ b/src/push/index.js
@@ -1,11 +1,8 @@
 import push from '../util/push-api'
 import * as load from '../util/load'
 import listr from '../util/modules/listr'
-import AWS from 'aws-sdk'
 
 export default async function (opts) {
-  AWS.config.update({region: opts.region})
-
   const apiId = opts.apiId
   const region = opts.region
   const api = await load.api()

--- a/src/run/index.js
+++ b/src/run/index.js
@@ -3,7 +3,6 @@ import * as load from '../util/load'
 import build from '../util/build-functions'
 import Promise from 'bluebird'
 import chalk from 'chalk'
-import AWS from 'aws-sdk'
 import ctx from '../util/context'
 import cliui from 'cliui'
 
@@ -16,8 +15,6 @@ const results = { success: 'SUCCESS', error: 'ERROR', exception: 'EXCEPTION' }
 const awsNodeVersion = ['4.3.2', '6.10.2']
 
 export default async function (opts) {
-  AWS.config.update({region: opts.region})
-
   const processVersion = process.versions.node
 
   if (awsNodeVersion.indexOf(processVersion) === -1) {

--- a/src/util/aws/api-gateway.js
+++ b/src/util/aws/api-gateway.js
@@ -1,9 +1,11 @@
 import AWS from './'
+import loadRegion from './region-loader'
 import Promise from 'bluebird'
 
 export const DEPLOY_ATTEMPT_MAX = 2
 
-export function exportStage (restApiId, stageName) {
+export async function exportStage (restApiId, stageName) {
+  await loadRegion()
   const apiGateway = new AWS.APIGateway()
   const params = {
     restApiId,
@@ -20,6 +22,7 @@ export function exportStage (restApiId, stageName) {
 }
 
 export async function deploy (id, env, attempts = 1) {
+  await loadRegion()
   const apiGateway = new AWS.APIGateway()
 
   try {
@@ -32,7 +35,8 @@ export async function deploy (id, env, attempts = 1) {
   }
 }
 
-export function pushApi (api, id) {
+export async function pushApi (api, id) {
+  await loadRegion()
   const apiGateway = new AWS.APIGateway()
 
   let params = {
@@ -49,7 +53,8 @@ export function pushApi (api, id) {
   }
 }
 
-export function aliases (id) {
+export async function aliases (id) {
+  await loadRegion()
   const apiGateway = new AWS.APIGateway()
 
   let params = {

--- a/src/util/aws/cloudwatch-logs.js
+++ b/src/util/aws/cloudwatch-logs.js
@@ -1,6 +1,8 @@
 import AWS from './'
+import loadRegion from './region-loader'
 
 export async function getLogGroup ({ FunctionName }) {
+  await loadRegion()
   const cwLogs = new AWS.CloudWatchLogs()
   const expetedName = `/aws/lambda/${FunctionName}`
 
@@ -18,6 +20,7 @@ export async function getLogGroup ({ FunctionName }) {
 }
 
 export async function getLogStreams ({ logGroupName, functionVersion }) {
+  await loadRegion()
   const cwLogs = new AWS.CloudWatchLogs()
   const versionRegExp = new RegExp(`\\[${functionVersion}\\]`)
 
@@ -32,7 +35,8 @@ export async function getLogStreams ({ logGroupName, functionVersion }) {
   return logStreams.map(({ logStreamName }) => logStreamName).filter(versionRegExp.test)
 }
 
-export function getLogEvents ({ logGroupName, logStreamNames, start, end }) {
+export async function getLogEvents ({ logGroupName, logStreamNames, start, end }) {
+  await loadRegion()
   const cwLogs = new AWS.CloudWatchLogs()
 
   const params = {

--- a/src/util/aws/lambda.js
+++ b/src/util/aws/lambda.js
@@ -1,13 +1,17 @@
 import AWS from './'
+import loadRegion from '../aws/region-loader'
 import merge from 'lodash.merge'
 
-export function getFunction (params) {
+export async function getFunction (params) {
+  await loadRegion()
   const lambda = new AWS.Lambda()
 
   return lambda.getFunction(params).promise()
 }
 
 export async function isFunctionDeployed (FunctionName) {
+  await loadRegion()
+
   try {
     await getFunction({ FunctionName })
     return true
@@ -18,6 +22,7 @@ export async function isFunctionDeployed (FunctionName) {
 }
 
 export async function putFunction (env, config, ZipFile) {
+  await loadRegion()
   const lambda = new AWS.Lambda()
 
   validateConfig(config)
@@ -38,6 +43,7 @@ export async function putFunction (env, config, ZipFile) {
 }
 
 export async function putEnvironment (env, config, envVars) {
+  await loadRegion()
   const lambda = new AWS.Lambda()
 
   validateConfig(config)
@@ -63,6 +69,7 @@ export async function putEnvironment (env, config, envVars) {
 }
 
 export async function removeEnvVars (env, config, envVars) {
+  await loadRegion()
   const lambda = new AWS.Lambda()
 
   validateConfig(config)
@@ -81,6 +88,7 @@ export async function removeEnvVars (env, config, envVars) {
 }
 
 export async function getEnvironment (env, { FunctionName }) {
+  await loadRegion()
   const params = {
     FunctionName,
     Qualifier: env
@@ -98,7 +106,8 @@ export async function getEnvironment (env, { FunctionName }) {
   }
 }
 
-export function getAliasVersion ({ functionName, aliasName }) {
+export async function getAliasVersion ({ functionName, aliasName }) {
+  await loadRegion()
   const lambda = new AWS.Lambda()
 
   const params = {
@@ -111,6 +120,7 @@ export function getAliasVersion ({ functionName, aliasName }) {
 }
 
 export async function publishFunction ({ FunctionName }, env) {
+  await loadRegion()
   const lambda = new AWS.Lambda()
 
   const func = await lambda.publishVersion({ FunctionName }).promise()
@@ -118,6 +128,7 @@ export async function publishFunction ({ FunctionName }, env) {
 }
 
 export async function setAlias ({ Version, FunctionName }, Name) {
+  await loadRegion()
   const lambda = new AWS.Lambda()
 
   let params = {
@@ -137,6 +148,7 @@ export async function setAlias ({ Version, FunctionName }, Name) {
 }
 
 export async function setPermission ({ name, region, env, apiId, accountId }) {
+  await loadRegion()
   const lambda = new AWS.Lambda()
 
   let params = {
@@ -157,7 +169,8 @@ export async function setPermission ({ name, region, env, apiId, accountId }) {
   }
 }
 
-export function listAliases (functionName) {
+export async function listAliases (functionName) {
+  await loadRegion()
   const lambda = new AWS.Lambda()
 
   const params = {

--- a/src/util/aws/region-loader.js
+++ b/src/util/aws/region-loader.js
@@ -1,0 +1,9 @@
+import AWS from './'
+import { pkg } from '../load'
+
+export default async function () {
+  if (!AWS.config.region) {
+    const { shep } = await pkg()
+    AWS.config.update({ region: shep.region })
+  }
+}

--- a/src/util/aws/s3.js
+++ b/src/util/aws/s3.js
@@ -1,6 +1,8 @@
 import AWS from './'
+import loadRegion from './region-loader'
 
 export async function putBuild (hash, path, bucket, func) {
+  await loadRegion()
   const s3 = new AWS.S3()
 
   const getParams = { Bucket: bucket, Key: hash }

--- a/src/util/load.js
+++ b/src/util/load.js
@@ -1,13 +1,9 @@
 import { readdir, readJSON } from './modules/fs'
 import minimatch from 'minimatch'
-import AWS from './aws'
 import { listAliases, isFunctionDeployed } from './aws/lambda'
 import Promise from 'bluebird'
 
 export async function envs () {
-  const pkg = await this.pkg()
-  AWS.config.update({ region: pkg.shep.region })
-
   const fullFuncNames = await Promise.map(this.funcs(), this.lambdaConfig)
   .map(({ FunctionName }) => FunctionName)
 


### PR DESCRIPTION
We were doing a bunch of `AWS.config.update({ region: region })` in a ton of different places and including in some of the command parsers. This meant that when trying to use shep pragmatically and not as a cli some of the functions didn't work. Didn't touch `iam.js` since those api calls don't need a region.

Really just want to be able to call `shep.configList` and get back an object of an environment