### PR TITLE
Alter deploy to display the version of functions deployed

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ Shep will require your amazon credentials and will load them using the same meth
 
 ### AWS S3 Build Artifacts
 
-Shep stores build artifacts on S3 so it can skip the upload step when your functions don't change. By default, Lambda won't update the version of an alias unless the function has changed - so this will come into effect for deploys of config changes.
+Shep stores build artifacts on S3 so it can skip the upload step when your functions don't change. By default, Lambda won't update the version of an alias unless the function has changed - so this will come into effect for deploys of config changes. This isn't enabled by default, to enable it add the name of the S3 bucket to the `"bucket"` field in the `shep` version of your `package.json`.
 
 ### Installation
 

--- a/src/commands/config/remove.js
+++ b/src/commands/config/remove.js
@@ -36,10 +36,12 @@ export async function handler (opts) {
 
   logger({ type: 'start', body: 'Remove environment variables on functions in AWS' })
   try {
-    await configRemove(merge({}, inputs, opts))
+    const versions = await configRemove(merge({}, inputs, opts))
+    logger({ type: 'done' })
+    logger(`Removed ${opts.vars.join(', ')} from ${inputs.env}`)
+    versions.forEach(({ name, FunctionVersion }) => logger(`Updated ${name} to version ${FunctionVersion}`))
   } catch (e) {
     logger({ type: 'fail' })
     throw e
   }
-  logger({ type: 'done', body: `Removed ${opts.vars.join(', ')} from ${inputs.env}` })
 }

--- a/src/commands/config/set.js
+++ b/src/commands/config/set.js
@@ -41,10 +41,11 @@ export async function handler (opts) {
 
   logger({ type: 'start', body: 'Set environment variables on functions in AWS' })
   try {
-    await configSet(merge({}, inputs, opts))
+    const versions = await configSet(merge({}, inputs, opts))
+    logger({ type: 'done' })
+    versions.forEach(({ name, FunctionVersion }) => logger(`Updated ${name} to version ${FunctionVersion}`))
   } catch (e) {
     logger({ type: 'fail' })
     throw e
   }
-  logger({ type: 'done' })
 }

--- a/src/commands/config/sync.js
+++ b/src/commands/config/sync.js
@@ -33,11 +33,12 @@ export async function handler (opts) {
   await Promise.each([...aliases], async (alias) => {
     try {
       logger({ type: 'start', body: `Syncing ${alias} environment across all functions` })
-      await sync({ env: alias })
+      const versions = await sync({ env: alias })
+      logger({ type: 'done' })
+      versions.forEach(({ name, FunctionVersion }) => logger(`Updated ${name} to version ${FunctionVersion} for ${alias}`))
     } catch (e) {
       logger({ type: 'fail' })
       throw e
     }
   })
-  logger({ type: 'done' })
 }

--- a/src/config-set/index.js
+++ b/src/config-set/index.js
@@ -1,5 +1,5 @@
-import upload from '../util/upload-environment'
+import uploadEnvironment from '../util/upload-environment'
 
 export default function ({ env = 'development', vars }) {
-  return upload(env, vars)
+  return uploadEnvironment(env, vars)
 }

--- a/src/config-sync/index.js
+++ b/src/config-sync/index.js
@@ -20,6 +20,5 @@ export default async function ({ env }) {
     return acc
   }, common)
 
-  await uploadEnvironment(env, combinedEnvironment)
-  return combinedEnvironment
+  return uploadEnvironment(env, combinedEnvironment)
 }

--- a/src/util/promote-aliases.js
+++ b/src/util/promote-aliases.js
@@ -1,8 +1,0 @@
-import { publishFunction } from './aws/lambda'
-import Promise from 'bluebird'
-import { lambdaConfig, funcs } from './load'
-
-export default async function (pattern, env) {
-  const configs = await Promise.map(funcs(pattern), lambdaConfig)
-  return Promise.map(configs, (config) => publishFunction(config, env))
-}

--- a/src/util/remove-environment.js
+++ b/src/util/remove-environment.js
@@ -1,10 +1,11 @@
 import Promise from 'bluebird'
+import merge from 'lodash.merge'
 import { removeEnvVars } from './aws/lambda'
 import { lambdaConfig, funcs } from './load'
 
 const pattern = '*'
 
 export default async function (env, vars) {
-  const configs = await Promise.map(funcs(pattern), lambdaConfig)
-  return Promise.map(configs, (config) => removeEnvVars(env, config, vars))
+  const configs = await Promise.map(funcs(pattern), async (name) => { return { name, config: await lambdaConfig(name) } })
+  return Promise.map(configs, async ({ name, config }) => merge({ name }, await removeEnvVars(env, config, vars)), { concurrency: 1 })
 }

--- a/src/util/upload-environment.js
+++ b/src/util/upload-environment.js
@@ -1,10 +1,14 @@
 import Promise from 'bluebird'
+import merge from 'lodash.merge'
 import { putEnvironment } from './aws/lambda'
 import { lambdaConfig, funcs } from './load'
 
 const pattern = '*'
 
 export default async function (env, vars) {
-  const configs = await Promise.map(funcs(pattern), lambdaConfig)
-  return Promise.map(configs, (config) => putEnvironment(env, config, vars), { concurrency: 2 })
+  const configs = await Promise.map(funcs(pattern), async (name) => { return { name, config: await lambdaConfig(name) } })
+  return Promise.map(configs, async ({name, config}) => {
+    const alias = await putEnvironment(env, config, vars)
+    return merge({ name }, alias)
+  }, { concurrency: 1 })
 }

--- a/test/commands/index.js
+++ b/test/commands/index.js
@@ -121,7 +121,7 @@ const webpackArgs = {
 test([allFlags, noFlags], 'webpack', webpackParser, webpackArgs)
 
 const configRemove = td.replace('../../src/config-remove')
-td.when(configRemove(), { ignoreExtraArgs: true }).thenResolve()
+td.when(configRemove(), { ignoreExtraArgs: true }).thenResolve([])
 const removeParser = yargs.command(require('../../src/commands/config/remove'))
 
 test('config remove command', (t) => {
@@ -131,7 +131,7 @@ test('config remove command', (t) => {
 })
 
 const configSet = td.replace('../../src/config-set')
-td.when(configSet(), { ignoreExtraArgs: true }).thenResolve()
+td.when(configSet(), { ignoreExtraArgs: true }).thenResolve([])
 const setParser = yargs.command(require('../../src/commands/config/set'))
 
 test('config set command', (t) => {

--- a/test/deploy/index-no-api.js
+++ b/test/deploy/index-no-api.js
@@ -1,7 +1,7 @@
 import test from 'ava'
 import td from '../helpers/testdouble'
 
-const functions = 'foo-*'
+const functions = '*'
 const uploadedFuncs = ['foo', 'bar']
 const env = 'beta'
 const bucket = 's3_bucket'
@@ -10,8 +10,8 @@ const build = td.replace('../../src/util/build-functions')
 td.when(build(), { ignoreExtraArgs: true }).thenResolve()
 const apiGateway = td.replace('../../src/util/aws/api-gateway')
 td.when(apiGateway.deploy(), { ignoreExtraArgs: true }).thenResolve()
-const promoteAliases = td.replace('../../src/util/promote-aliases')
-td.when(promoteAliases(), { ignoreExtraArgs: true }).thenResolve()
+const lambda = td.replace('../../src/util/aws/lambda')
+td.when(lambda.publishFunction(), { ignoreExtraArgs: true }).thenResolve({})
 const setPermissions = td.replace('../../src/util/set-permissions')
 td.when(setPermissions(), { ignoreExtraArgs: true }).thenResolve()
 const push = td.replace('../../src/util/push-api')
@@ -19,6 +19,8 @@ td.when(push(), { ignoreExtraArgs: true }).thenResolve()
 
 const load = td.replace('../../src/util/load')
 td.when(load.api()).thenResolve()
+td.when(load.funcs(functions)).thenResolve(uploadedFuncs)
+td.when(load.lambdaConfig(td.matchers.isA(String))).thenResolve({})
 
 const uploadBuilds = td.replace('../../src/util/upload-builds')
 td.when(uploadBuilds(functions, bucket)).thenResolve(uploadedFuncs)
@@ -44,7 +46,7 @@ test('Does not push API defenitin', () => {
 })
 
 test('Does promote function aliases', () => {
-  td.verify(promoteAliases(functions, env))
+  td.verify(lambda.publishFunction(td.matchers.isA(Object), env), { times: uploadedFuncs.length })
 })
 
 test('Does not setup function permissions', () => {

--- a/test/deploy/index-no-build.js
+++ b/test/deploy/index-no-build.js
@@ -1,7 +1,7 @@
 import test from 'ava'
 import td from '../helpers/testdouble'
 
-const functions = 'foo-*'
+const functions = '*'
 const uploadedFuncs = ['foo', 'bar']
 const env = 'beta'
 const bucket = 's3_bucket'
@@ -12,13 +12,15 @@ const build = td.replace('../../src/util/build-functions')
 td.when(build(), { ignoreExtraArgs: true }).thenResolve()
 const apiGateway = td.replace('../../src/util/aws/api-gateway')
 td.when(apiGateway.deploy(), { ignoreExtraArgs: true }).thenResolve()
-const promoteAliases = td.replace('../../src/util/promote-aliases')
-td.when(promoteAliases(), { ignoreExtraArgs: true }).thenResolve()
+const lambda = td.replace('../../src/util/aws/lambda')
+td.when(lambda.publishFunction(), { ignoreExtraArgs: true }).thenResolve({})
 const setPermissions = td.replace('../../src/util/set-permissions')
 td.when(setPermissions(), { ignoreExtraArgs: true }).thenResolve()
 
 const load = td.replace('../../src/util/load')
 td.when(load.api()).thenResolve(api)
+td.when(load.funcs(functions)).thenResolve(uploadedFuncs)
+td.when(load.lambdaConfig(td.matchers.isA(String))).thenResolve({})
 
 const push = td.replace('../../src/util/push-api')
 td.when(push(api), { ignoreExtraArgs: true }).thenResolve(apiId)
@@ -43,7 +45,7 @@ test('Deploys API', () => {
 })
 
 test('Promote function aliases', () => {
-  td.verify(promoteAliases(functions, env))
+  td.verify(lambda.publishFunction(td.matchers.isA(Object), env), { times: uploadedFuncs.length })
 })
 
 test('Setup function permissions', () => {

--- a/test/deploy/index-use-artifacts.js
+++ b/test/deploy/index-use-artifacts.js
@@ -12,15 +12,15 @@ const build = td.replace('../../src/util/build-functions')
 td.when(build(), { ignoreExtraArgs: true }).thenResolve()
 const apiGateway = td.replace('../../src/util/aws/api-gateway')
 td.when(apiGateway.deploy(), { ignoreExtraArgs: true }).thenResolve()
-
-const promoteAliases = td.replace('../../src/util/promote-aliases')
-td.when(promoteAliases(functions, env)).thenResolve(uploadedFuncs)
+const lambda = td.replace('../../src/util/aws/lambda')
+td.when(lambda.publishFunction(), { ignoreExtraArgs: true }).thenResolve({})
 
 const setPermissions = td.replace('../../src/util/set-permissions')
 td.when(setPermissions(), { ignoreExtraArgs: true }).thenResolve()
 
 const load = td.replace('../../src/util/load')
 td.when(load.api()).thenResolve(api)
+td.when(load.funcs(td.matchers.isA(String))).thenResolve([])
 
 const push = td.replace('../../src/util/push-api')
 td.when(push(api), { ignoreExtraArgs: true }).thenResolve(apiId)

--- a/test/deploy/index.js
+++ b/test/deploy/index.js
@@ -1,7 +1,7 @@
 import test from 'ava'
 import td from '../helpers/testdouble'
 
-const functions = 'foo-*'
+const functions = '*'
 const uploadedFuncs = ['foo', 'bar']
 const env = 'beta'
 const bucket = 's3_bucket'
@@ -12,13 +12,15 @@ const build = td.replace('../../src/util/build-functions')
 td.when(build(), { ignoreExtraArgs: true }).thenResolve()
 const apiGateway = td.replace('../../src/util/aws/api-gateway')
 td.when(apiGateway.deploy(), { ignoreExtraArgs: true }).thenResolve()
-const promoteAliases = td.replace('../../src/util/promote-aliases')
-td.when(promoteAliases(), { ignoreExtraArgs: true }).thenResolve()
+const lambda = td.replace('../../src/util/aws/lambda')
+td.when(lambda.publishFunction(), { ignoreExtraArgs: true }).thenResolve({})
 const setPermissions = td.replace('../../src/util/set-permissions')
 td.when(setPermissions(), { ignoreExtraArgs: true }).thenResolve()
 
 const load = td.replace('../../src/util/load')
 td.when(load.api()).thenResolve(api)
+td.when(load.funcs(functions)).thenResolve(uploadedFuncs)
+td.when(load.lambdaConfig(td.matchers.isA(String))).thenResolve({})
 
 const push = td.replace('../../src/util/push-api')
 td.when(push(api), { ignoreExtraArgs: true }).thenResolve(apiId)
@@ -43,7 +45,7 @@ test('Deploys API', () => {
 })
 
 test('Promote function aliases', () => {
-  td.verify(promoteAliases(functions, env))
+  td.verify(lambda.publishFunction(td.matchers.isA(Object), env), { times: uploadedFuncs.length })
 })
 
 test('Setup function permissions', () => {


### PR DESCRIPTION
Closes #267. Does this look like what you want @reconbot?

```
✔ Build Functions
→ Skipping uploading builds, no S3 bucket provided
✔ Upload Functions to AWS
✔ Upload API.json
✔ Promote Function Aliases
✔ Setup Lambda Permissions
✔ Deploy API
Deployed version 254 for foo
Deployed version 254 for test-get
```
Now also displays this on all functions that publish new versions