### PR TITLE
Use region from shep config when generating JSON schema

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ node_modules/*
 npm-debug.log
 lib/
 tmp/
+*.swp

--- a/test-ava/generate-endpoint/index.js
+++ b/test-ava/generate-endpoint/index.js
@@ -10,15 +10,15 @@ const path = '/foo'
 const method = 'get'
 const accountId = 'testid'
 
-let shep;
+let shep
 
 td.when(fs.readJSON('package.json')).thenResolve({ name: 'bar', shep: {} })
 td.when(fs.writeJSON(), { ignoreExtraArgs: true }).thenResolve()
 
-const functionName = 'noice-name-bro';
+const functionName = 'noice-name-bro'
 const generateName = td.replace('../../src/util/generate-name')
 td.when(generateName(), { ignoreExtraArgs: true }).thenResolve({
-  fullName: functionName,
+  fullName: functionName
 })
 
 test.before(async () => {
@@ -26,10 +26,10 @@ test.before(async () => {
 })
 
 test.beforeEach((t) => {
-  t.context.paths = {};
+  t.context.paths = {}
 
   td.when(load.api()).thenResolve({ paths: t.context.paths })
-});
+})
 
 test('Writes a new api.json file', async () => {
   await shep.generateEndpoint({ accountId, path, method })
@@ -48,11 +48,11 @@ const constructIntegrationObject = (accountId, region) => ({
   uri: `arn:aws:apigateway:${region}:lambda:path/2015-03-31/functions/arn:aws:lambda:${region}:${accountId}:function:${functionName}:\${stageVariables.functionAlias}/invocations`,
   passthroughBehavior: 'when_no_match',
   httpMethod: 'POST',
-  type: 'aws_proxy',
+  type: 'aws_proxy'
 })
 
 test('adds a basic api path', async (t) => {
-  const region = 'us-west-2';
+  const region = 'us-west-2'
 
   await shep.generateEndpoint({ accountId, path, method, region })
 
@@ -64,4 +64,3 @@ test('defaults to us-east-1 region', async (t) => {
 
   t.deepEqual(t.context.paths[path][method][integration], constructIntegrationObject(accountId, 'us-east-1'))
 })
-

--- a/test-ava/generate-endpoint/index.js
+++ b/test-ava/generate-endpoint/index.js
@@ -10,19 +10,58 @@ const path = '/foo'
 const method = 'get'
 const accountId = 'testid'
 
+let shep;
+
 td.when(fs.readJSON('package.json')).thenResolve({ name: 'bar', shep: {} })
 td.when(fs.writeJSON(), { ignoreExtraArgs: true }).thenResolve()
-td.when(load.api()).thenResolve({ paths: {} })
 
-test.before(() => {
-  const shep = require('../../src/index')
-  return shep.generateEndpoint({ accountId, path, method })
+const functionName = 'noice-name-bro';
+const generateName = td.replace('../../src/util/generate-name')
+td.when(generateName(), { ignoreExtraArgs: true }).thenResolve({
+  fullName: functionName,
 })
 
-test('Writes a new api.json', () => {
+test.before(async () => {
+  shep = require('../../src/index')
+})
+
+test.beforeEach((t) => {
+  t.context.paths = {};
+
+  td.when(load.api()).thenResolve({ paths: t.context.paths })
+});
+
+test('Writes a new api.json file', async () => {
+  await shep.generateEndpoint({ accountId, path, method })
+
   td.verify(fs.writeJSON('api.json'), { ignoreExtraArgs: true })
 })
 
-test('Generates a new function', () => {
+test('Generates a new function', async () => {
+  await shep.generateEndpoint({ accountId, path, method })
   td.verify(generateFunction(td.matchers.contains({ name: '/foo get' })))
 })
+
+const integration = 'x-amazon-apigateway-integration'
+
+const constructIntegrationObject = (accountId, region) => ({
+  uri: `arn:aws:apigateway:${region}:lambda:path/2015-03-31/functions/arn:aws:lambda:${region}:${accountId}:function:${functionName}:\${stageVariables.functionAlias}/invocations`,
+  passthroughBehavior: 'when_no_match',
+  httpMethod: 'POST',
+  type: 'aws_proxy',
+})
+
+test('adds a basic api path', async (t) => {
+  const region = 'us-west-2';
+
+  await shep.generateEndpoint({ accountId, path, method, region })
+
+  t.deepEqual(t.context.paths[path][method][integration], constructIntegrationObject(accountId, region))
+})
+
+test('defaults to us-east-1 region', async (t) => {
+  await shep.generateEndpoint({ accountId, path, method })
+
+  t.deepEqual(t.context.paths[path][method][integration], constructIntegrationObject(accountId, 'us-east-1'))
+})
+


### PR DESCRIPTION
Current:
static reference to `us-east-1` in generated JSON uri

Changed: 
Use the` region` from the `shep` section in the package.json file in generating uris for the JSON schema file `api.json`. Keep `us-east-1` as default region if not provided.

Some Questions:
Is the `region` specified by the project a default region? If not, then when deploying to multiple regions, does that value need to be set each time?