### PR TITLE
dont assume the new target function has an identifier, in case its a new variable getting set

### DIFF
--- a/src/util/aws/lambda.js
+++ b/src/util/aws/lambda.js
@@ -86,7 +86,7 @@ export async function updateFunction (oldFunction, wantedFunction) {
   await loadRegion()
   const lambda = new AWS.Lambda()
   const { FunctionName } = oldFunction
-  const Alias = wantedFunction.Identifier.Alias || oldFunction.Identifier.Alias
+  const Alias = wantedFunction.hasOwnProperty('Identifier') ? wantedFunction.Identifier.Alias || oldFunction.Identifier.Alias : oldFunction.Identifier.Alias
   const updateCodeParams = { FunctionName }
   const updateConfigParams = { FunctionName }
   const publishVersionParams = { FunctionName }


### PR DESCRIPTION
I'm not sure this is entirely the right place for this, but it addresses the issue I had whereby doing:

```
$ shep config set FOO=bar
```

Would error with:

```
TypeError: Cannot read property 'Alias' of undefined
    at /home/dave/dev/lambda-alerts/node_modules/shep/lib/util/aws/lambda.js:115:42
    at next (native)
    at tryCatcher (/home/dave/dev/lambda-alerts/node_modules/bluebird/js/release/util.js:16:23)
    at PromiseSpawn._promiseFulfilled (/home/dave/dev/lambda-alerts/node_modules/bluebird/js/release/generators.js:97:49)
    at Async._drainQueue (/home/dave/dev/lambda-alerts/node_modules/bluebird/js/release/async.js:138:12)
    at Async._drainQueues (/home/dave/dev/lambda-alerts/node_modules/bluebird/js/release/async.js:143:10)
    at Immediate.Async.drainQueues (/home/dave/dev/lambda-alerts/node_modules/bluebird/js/release/async.js:17:14)
    at runCallback (timers.js:672:20)
    at tryOnImmediate (timers.js:645:5)
    at processImmediate [as _immediateCallback] (timers.js:617:5)
```

The bigger question is probably: why is `updateFunction` getting passed a partially initialized function?