### PR TITLE
Per environment lamba configuration JSON files

### DIFF
--- a/src/config-sync/index.js
+++ b/src/config-sync/index.js
@@ -6,7 +6,7 @@ import uploadEnvironment from '../util/upload-environment'
 import { funcs, lambdaConfig } from '../util/load'
 
 export default async function ({ env }) {
-  const configs = await Promise.map(funcs(), lambdaConfig)
+  const configs = await Promise.map(funcs(), (func) => lambdaConfig(func, env))
   const environments = await getFunctionEnvs(env, configs)
   const { common, differences, conflicts } = environmentCheck(environments)
 

--- a/src/logs/index.js
+++ b/src/logs/index.js
@@ -5,7 +5,7 @@ import getLogs from '../util/get-logs'
 import { lambdaConfig } from '../util/load'
 
 export default async function ({ name, env, time = Infinity, logger = () => {} }) {
-  const { FunctionName } = await lambdaConfig(name)
+  const { FunctionName } = await lambdaConfig(name, env)
   const aliasName = env
 
   const [logGroupName, functionVersion] = await Promise.all([getLogGroup({ FunctionName }), getAliasVersion({ functionName: FunctionName, aliasName })])

--- a/src/run/index.js
+++ b/src/run/index.js
@@ -41,7 +41,7 @@ function runFunction (opts) {
   return async (name) => {
     const env = opts.environment || 'development'
     const performBuild = opts.build
-    const lambdaConfig = await load.lambdaConfig(name)
+    const lambdaConfig = await load.lambdaConfig(name, env)
     const events = await load.events(name, opts.event)
     const [ fileName, handler ] = lambdaConfig.Handler.split('.')
 

--- a/src/util/get-environment.js
+++ b/src/util/get-environment.js
@@ -3,6 +3,6 @@ import { getEnvironment } from './aws/lambda'
 import { lambdaConfig, funcs } from './load'
 
 export default async function (env, name) {
-  const configs = await Promise.map(funcs(name), lambdaConfig)
+  const configs = await Promise.map(funcs(name), (func) => lambdaConfig(func, env))
   return Promise.map(configs, (config) => getEnvironment(env, config))
 }

--- a/src/util/load.js
+++ b/src/util/load.js
@@ -53,11 +53,13 @@ export async function funcs (pattern = '*') {
   return funcs
 }
 
-export async function lambdaConfig (name) {
+export async function lambdaConfig (name, env = null) {
   const functionConfig = await readJSON(`functions/${name}/lambda.json`)
+  const functionEnvConfig = env ? await readJSON(`functions/${name}/lambda.${env}.json`) : {}
   const projectConfig = await readJSON(`lambda.json`)
+  const projectEnvConfig = env ? await readJSON(`lambda.${env}.json`) : {}
 
-  return Object.assign({}, projectConfig, functionConfig)
+  return Object.assign({}, projectConfig, projectEnvConfig, functionConfig, functionEnvConfig)
 }
 
 export async function pkg () {

--- a/src/util/upload-functions.js
+++ b/src/util/upload-functions.js
@@ -6,7 +6,7 @@ import zipDir from './zip-dir'
 
 export default async function (fns, env) {
   return Promise.map(fns, async ({ name, key, bucket }) => {
-    const config = await lambdaConfig(name)
+    const config = await lambdaConfig(name, env)
     let wantedFunc = { Config: config, Code: {}, Identifier: {} }
 
     if (bucket && key) {


### PR DESCRIPTION
This PR allows shep to read `lambda.{env}.json` files in the project and function directories. This should allow more flexibility when deploying to VPCs in different environments, as well as using different runtimes (nodejs4.3, nodejs6.10, etc)  in a dev environment before upgrading a prod environment. 